### PR TITLE
Add buffered write methods to RedisWrite

### DIFF
--- a/redis/src/cmd.rs
+++ b/redis/src/cmd.rs
@@ -282,6 +282,14 @@ impl RedisWrite for Cmd {
         write!(self.data, "{arg}").unwrap();
         self.args.push(Arg::Simple(self.data.len()));
     }
+
+    fn start_buffered_arg(&mut self) {}
+    fn write_buffered_arg(&mut self, arg: &[u8]) {
+        self.data.extend_from_slice(arg);
+    }
+    fn finish_buffered_arg(&mut self) {
+        self.args.push(Arg::Simple(self.data.len()));
+    }
 }
 
 impl Default for Cmd {

--- a/redis/src/types.rs
+++ b/redis/src/types.rs
@@ -749,6 +749,17 @@ pub trait RedisWrite {
     fn write_arg_fmt(&mut self, arg: impl fmt::Display) {
         self.write_arg(arg.to_string().as_bytes())
     }
+
+    /// Start a buffered argument.
+    fn start_buffered_arg(&mut self);
+
+    /// Write to an existing buffered argument. If `start_buffered_arg` wasn't
+    /// called first, this may panic.
+    fn write_buffered_arg(&mut self, arg: &[u8]);
+
+    /// Finalize a buffered argument. If this isn't called after
+    /// `start_buffered_arg`, the command will not be well-formed
+    fn finish_buffered_arg(&mut self);
 }
 
 impl RedisWrite for Vec<Vec<u8>> {
@@ -759,6 +770,14 @@ impl RedisWrite for Vec<Vec<u8>> {
     fn write_arg_fmt(&mut self, arg: impl fmt::Display) {
         self.push(arg.to_string().into_bytes())
     }
+
+    fn start_buffered_arg(&mut self) {
+        self.push(Vec::new());
+    }
+    fn write_buffered_arg(&mut self, arg: &[u8]) {
+        self.last_mut().unwrap().extend_from_slice(arg);
+    }
+    fn finish_buffered_arg(&mut self) {}
 }
 
 /// Used to convert a value into one or multiple redis argument


### PR DESCRIPTION
This will enable "compatibility" with std::io::Write based serializers in ToRedisArgs implementations